### PR TITLE
Update versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -5,8 +5,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.28
+          version: v1.50.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.14]
+        go-version: [1.19]
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Set up Go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -40,7 +39,6 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    # - structcheck # Disabled for lack of generics support
     - tagliatelle
     - testpackage
     - thelper
@@ -48,8 +46,6 @@ linters:
     - typecheck
     - unconvert
     - unused
-    - varcheck
-    # - wastedassign # Disabled for lack of generics support
     - whitespace
 
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,59 @@
-service:
-  golangci-lint-version: 1.28.x
-
 run:
   deadline: 5m
 
 linters:
-  enable-all: true
+  disable-all: true
 
-  # linters are disabled if their majority of issues is considered false-positive (intended code)
-  # and the remaining issues (if existing) aren't worth it.
-  disable:
-    - wsl # too pedantic/subjective
-    - gofumpt # Stick to standard gofmt
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errorlint
+    - exportloopref
+    - forbidigo
+    - goconst
+    - gocritic
+    - godot
+    - godox
+    - goerr113
+    - gofmt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - noctx
+    - nolintlint
+    - predeclared
+    - promlinter
+    - revive
+    - staticcheck
+    # - structcheck # Disabled for lack of generics support
+    - tagliatelle
+    - testpackage
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    # - wastedassign # Disabled for lack of generics support
+    - whitespace
 
 issues:
   exclude-use-default: false # disable filtering of defaults for better zero-issue policy
-  exclude:
   max-per-linter: 0 # disable limit; report all issues of a linter
   max-same-issues: 0 # disable limit; report all issues of the same issue
 

--- a/cmd/goconsider/main.go
+++ b/cmd/goconsider/main.go
@@ -1,3 +1,4 @@
+// Package main provides the main entry function for the standalone linter executable.
 package main
 
 import (

--- a/cmd/goconsider/run.go
+++ b/cmd/goconsider/run.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,10 +24,12 @@ type arguments struct {
 	settings     string
 }
 
-type issuesFoundError int
+type issuesFoundError struct {
+	number int
+}
 
 func (err issuesFoundError) Error() string {
-	return fmt.Sprintf("%v issues were found", int(err))
+	return fmt.Sprintf("%v issues were found", err.number)
 }
 
 func run(out io.Writer, rawArgs []string) error {
@@ -57,7 +58,7 @@ func run(out io.Writer, rawArgs []string) error {
 	}
 	issueCount := lintAndReport(out, reportTo(out), fset, files, settings, !args.noReferences)
 	if issueCount > 0 {
-		return issuesFoundError(issueCount)
+		return issuesFoundError{number: issueCount}
 	}
 	return nil
 }
@@ -73,7 +74,7 @@ func defaultSettings() (goconsider.Settings, error) {
 }
 
 func parseSettings(filename string) (goconsider.Settings, error) {
-	settingsData, err := ioutil.ReadFile(filename) // nolint: gosec
+	settingsData, err := os.ReadFile(filename)
 	if err != nil {
 		return goconsider.Settings{}, err
 	}

--- a/cmd/goconsider/run.go
+++ b/cmd/goconsider/run.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/dertseha/goconsider"
 )

--- a/cmd/goconsider/run_test.go
+++ b/cmd/goconsider/run_test.go
@@ -1,7 +1,8 @@
-package main // nolint: testpackage
+package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path"
 	"testing"
@@ -12,7 +13,7 @@ func TestReportIssuesWithDefaultSettings(t *testing.T) {
 	err := run(out, []string{path.Join(".", "testdata", "issues", "default.go")})
 	if err == nil {
 		t.Errorf("error expected")
-	} else if _, isOK := err.(issuesFoundError); !isOK {
+	} else if !errors.As(err, &issuesFoundError{}) {
 		t.Errorf("unexpected error returned: %v", err)
 	}
 }
@@ -25,7 +26,7 @@ func TestReportIssuesWithExplicitSettings(t *testing.T) {
 	})
 	if err == nil {
 		t.Errorf("error expected")
-	} else if _, isOK := err.(issuesFoundError); !isOK {
+	} else if !errors.As(err, &issuesFoundError{}) {
 		t.Errorf("unexpected error returned: %v", err)
 	}
 }
@@ -41,7 +42,7 @@ func TestReportIssuesWithImplicitSettings(t *testing.T) {
 	})
 	if err == nil {
 		t.Errorf("error expected")
-	} else if _, isOK := err.(issuesFoundError); !isOK {
+	} else if !errors.As(err, &issuesFoundError{}) {
 		t.Errorf("unexpected error returned: %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dertseha/goconsider
 
-go 1.14
+go 1.19
 
-require gopkg.in/yaml.v2 v2.3.0
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/goconsider_test.go
+++ b/goconsider_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dertseha/goconsider"
 )
 
-// nolint: funlen
 func TestLint(t *testing.T) {
 	makeIssue := func(line, col int, prefix string) goconsider.Issue {
 		return goconsider.Issue{


### PR DESCRIPTION
This PR is updating all the used versions, and adapting the code accordingly.
* Go to 1.19
* Dependencies (yaml) to newest version
* Linter to newest version
  * prefer disable-all, enable-explicitly approach in configuring linters
  * adapt code